### PR TITLE
make migrate folder neater

### DIFF
--- a/db/migrate/20220209153639_create_articles.rb
+++ b/db/migrate/20220209153639_create_articles.rb
@@ -3,6 +3,7 @@ class CreateArticles < ActiveRecord::Migration[7.0]
     create_table :articles do |t|
       t.string :title
       t.text :body
+      t.string :status
 
       t.timestamps
     end

--- a/db/migrate/20220214021745_create_comments.rb
+++ b/db/migrate/20220214021745_create_comments.rb
@@ -3,6 +3,7 @@ class CreateComments < ActiveRecord::Migration[7.0]
     create_table :comments do |t|
       t.string :commenter
       t.text :body
+      t.string :status
       t.references :article, null: false, foreign_key: true
 
       t.timestamps

--- a/db/migrate/20220214135820_add_status_to_articles.rb
+++ b/db/migrate/20220214135820_add_status_to_articles.rb
@@ -1,5 +1,0 @@
-class AddStatusToArticles < ActiveRecord::Migration[7.0]
-  def change
-    add_column :articles, :status, :string
-  end
-end

--- a/db/migrate/20220214140325_add_status_to_comments.rb
+++ b/db/migrate/20220214140325_add_status_to_comments.rb
@@ -1,5 +1,0 @@
-class AddStatusToComments < ActiveRecord::Migration[7.0]
-  def change
-    add_column :comments, :status, :string
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,9 +15,9 @@ ActiveRecord::Schema.define(version: 2022_02_16_141817) do
   create_table "articles", force: :cascade do |t|
     t.string "title"
     t.text "body"
+    t.string "status"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "status"
     t.integer "user_id"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
@@ -25,10 +25,10 @@ ActiveRecord::Schema.define(version: 2022_02_16_141817) do
   create_table "comments", force: :cascade do |t|
     t.string "commenter"
     t.text "body"
+    t.string "status"
     t.integer "article_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "status"
     t.index ["article_id"], name: "index_comments_on_article_id"
   end
 


### PR DESCRIPTION
- got rid of extra migration files, moving changes to initial migrations as instructed by senior dev.